### PR TITLE
fix(README): add precision on the local nature of LLDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Below you'll find detailed information about each supported engine
 
 #### LLDP
 
-LLDP (Link Layer Discovery Protocol) is a vendor-neutral Layer 2 protocol that enables network devices to automatically discover and share information about their identity, capabilities, and neighboring devices on a local network.
+LLDP (Link Layer Discovery Protocol) is a vendor-neutral Layer 2 protocol that enables network devices to automatically discover and share information about their identity, capabilities, and neighboring device on a local network link (physical cable or veth pair).
 
 It can be used in both bare-metal and virtualised environments to inform nodes about the underlying topology (eg: Proxmox PVE). In bare-metal environments, it must be enabled at the network device level (e.g., switches). In virtualised environments, you'll need to install the lldpd service on your hypervisors.
 


### PR DESCRIPTION
Since "local network" usually refers to a subnet/LAN, this change specifies that LLDP is only relevant on a single network link instead. LLDP frames are not forwarded by a physical or virtual bridge, so they do not reach other hosts in a subnet/LAN.
Also, remove the "s" of "neighboring devices" : given the local nature of LLDP, one usually only have a single LLDP neighbor. Except when using old hubs, but in 2026 this really tends to be an exception.